### PR TITLE
downgraded scikit in requirements.txt for Heroku

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ pickleshare==0.7.5
 psycopg2==2.9.2
 python-dateutil==2.8.2
 pytz==2021.3
-scikit-learn==1.0.1
-scipy==1.7.3
+scikit-learn==0.24.1
+scipy==1.6.2
 six==1.16.0
 SQLAlchemy==1.4.28
 threadpoolctl==3.0.0


### PR DESCRIPTION
Downgraded scikit and scipy to prevent errors from showing up.  We built at 0.24.1 of scikit